### PR TITLE
Добавлена поддержка js-runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pdm install
 FROM python:3.12-alpine AS runner
 WORKDIR /app
 
-RUN apk update && apk add --no-cache ffmpeg aria2
+RUN apk update && apk add --no-cache ffmpeg aria2 deno
 COPY --from=pybuilder /build/.venv/lib/ /usr/local/lib/
 COPY src /app
 WORKDIR /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Katze_942", email = "rs5334819@gmail.com"}
 ]
 
-dependencies = ["tgcrypto>=1.2.5", "yt-dlp[curl-cffi,default]==2025.10.22", "APScheduler>=3.11.0", "ffmpeg-python>=0.2.0", "PyMySQL>=1.1.1", "filetype>=1.2.0", "beautifulsoup4>=4.12.3", "fakeredis>=2.26.2", "redis==6.4.0", "requests>=2.32.3", "tqdm>=4.67.1", "token-bucket>=0.3.0", "python-dotenv>=1.0.1", "black>=24.10.0", "sqlalchemy>=2.0.36", "psutil>=6.1.0", "ffpb>=0.4.1", "kurigram==2.2.13", "cryptography>=43.0.3"]
+dependencies = ["tgcrypto>=1.2.5", "yt-dlp[curl-cffi,default]", "APScheduler>=3.11.0", "ffmpeg-python>=0.2.0", "PyMySQL>=1.1.1", "filetype>=1.2.0", "beautifulsoup4>=4.12.3", "fakeredis>=2.26.2", "redis==6.4.0", "requests>=2.32.3", "tqdm>=4.67.1", "token-bucket>=0.3.0", "python-dotenv>=1.0.1", "black>=24.10.0", "sqlalchemy>=2.0.36", "psutil>=6.1.0", "ffpb>=0.4.1", "kurigram==2.2.13", "cryptography>=43.0.3"]
 requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "Apache2.0"}


### PR DESCRIPTION
Согласно https://github.com/yt-dlp/yt-dlp/issues/15012:
- Добавлена зависимость deno (рекомендуемый вариант) в docker образ при его компиляции
- Удалена блокировка версии на yt-dlp, чтобы всегда скачивалась новая версия (таким образом скачивается также автоматически и yt-dlp-ejs)